### PR TITLE
Add spaces to printed data

### DIFF
--- a/lib/python/miauth/cli.py
+++ b/lib/python/miauth/cli.py
@@ -55,7 +55,7 @@ def nb_main(ble):
 
     if args.command:
         resp = nc.comm(args.command)
-        print("UART reply:", resp.hex())
+        print("UART reply:", resp.hex(" "))
 
     # NOTE: don't send checksums!
     if args.serial:
@@ -80,7 +80,7 @@ def m365_main(ble):
 
     if args.command:
         resp = mc.comm(args.command)
-        print("UART reply:", resp.hex())
+        print("UART reply:", resp.hex(" "))
 
     # NOTE: don't send checksums!
     if args.serial:
@@ -124,7 +124,7 @@ Caution: After registration this device will lose coupling to all other apps (re
     if args.command:
         print("Sending command:", args.command)
         resp = mc.comm(args.command)
-        print("UART reply:", resp.hex())
+        print("UART reply:", resp.hex(" "))
 
     # NOTE: don't send checksum
     if args.serial:

--- a/lib/python/miauth/mi/m365client.py
+++ b/lib/python/miauth/mi/m365client.py
@@ -73,7 +73,7 @@ class M365Client(btle.DefaultDelegate):
             self.key = self.ch_key[0].read()
             self.key += self.comm("55aa0322015020")[9:]
             if self.debug:
-                print("key:", self.key.hex())
+                print("key:", self.key.hex(" "))
 
     def comm(self, cmd):
         if type(cmd) not in [bytearray, bytes]:
@@ -101,7 +101,7 @@ class M365Client(btle.DefaultDelegate):
             raise Exception("No answer received. Firmware not supported.")
 
         if self.debug:
-            print("received:", self.received_data.hex())
+            print("received:", self.received_data.hex(" "))
         res = self.received_data
         if crc16(res[2:-2]) != res[-2:]:
             raise Exception("Checksum mismatch in response")
@@ -110,7 +110,7 @@ class M365Client(btle.DefaultDelegate):
             res = self.crypt(res[3:])[:-4]
 
         if self.debug:
-            print("response:", res.hex())
+            print("response:", res.hex(" "))
         return res[3:-2]
 
     def crypt(self, data):

--- a/lib/python/miauth/mi/miclient.py
+++ b/lib/python/miauth/mi/miclient.py
@@ -71,7 +71,7 @@ class MiClient(object):
 
         frm = data[0] + 0x100 * data[1]
         if self.debug:
-            print("<-", data.hex(), self.get_state())
+            print("<-", data.hex(" "), self.get_state())
 
         frm = data[0]
         if len(data) > 1:
@@ -126,7 +126,7 @@ class MiClient(object):
 
         if frm == self.receive_frames:
             if self.debug:
-                print("All frames received: ", self.received_data.hex())
+                print("All frames received: ", self.received_data.hex(" "))
             self.ble.write(UUID.AVDTP, MiCommand.RCV_OK)
             self.next_state()
 
@@ -173,12 +173,12 @@ class MiClient(object):
         did_ct = MiCrypto.encrypt_did(a, self.remote_info[4:])
 
         if self.debug:
-            print("eShareKey:", e_share_key.hex())
-            print("HKDF result: ", derived_key.hex())
-            print("token:", token.hex())
-            print("bind_key:", bind_key.hex())
-            print("A:", a.hex())
-            print("AES did CT: ", did_ct.hex())
+            print("eShareKey:", e_share_key.hex(" "))
+            print("HKDF result: ", derived_key.hex(" "))
+            print("token:", token.hex(" "))
+            print("bind_key:", bind_key.hex(" "))
+            print("A:", a.hex(" "))
+            print("AES did CT: ", did_ct.hex(" "))
 
         return did_ct, token
 
@@ -197,9 +197,9 @@ class MiClient(object):
         expected_remote_info = MiCrypto.hash(keys['dev_key'], salt_inv)
 
         if self.debug:
-            print("HKDF result:", derived_key.hex())
+            print("HKDF result:", derived_key.hex(" "))
             for key, val in keys.items():
-                print(f"{key.upper()}:", val.hex())
+                print(f"{key.upper()}:", val.hex(" "))
 
         return info, expected_remote_info, keys
 
@@ -207,7 +207,7 @@ class MiClient(object):
         priv_key, pub_key = MiCrypto.gen_keypair()
         if self.debug:
             print("Private Key (Val):", MiCrypto.private_key_to_val(priv_key))
-            print("Public Key (Hex):", MiCrypto.pub_key_to_bytes(pub_key).hex())
+            print("Public Key (Hex):", MiCrypto.pub_key_to_bytes(pub_key).hex(" "))
 
         def on_recv_info_state():
             self.ble.write(UUID.UPNP, MiCommand.CMD_GET_INFO)
@@ -280,7 +280,7 @@ class MiClient(object):
 
             self.send_data, expected_remote_info, self.keys = self.calc_login_info(rand_key)
             assert self.remote_info == expected_remote_info, \
-                f"{self.remote_info.hex()} != {expected_remote_info.hex()}"
+                f"{self.remote_info.hex(' ')} != {expected_remote_info.hex(' ')}"
             self.ble.write(UUID.AVDTP, MiCommand.CMD_SEND_INFO)
 
         self.seq = (

--- a/lib/python/miauth/nb/nbclient.py
+++ b/lib/python/miauth/nb/nbclient.py
@@ -59,8 +59,8 @@ class NbClient(object):
 
         dec = self.crypto.decrypt(self.receive_buffer)
         if self.debug:
-            print("Received message:", self.receive_buffer.hex())
-            print("Decoded message:", dec.hex())
+            print("Received message:", self.receive_buffer.hex(" "))
+            print("Decoded message:", dec.hex(" "))
 
         if len(dec) == self.receive_buffer[2] + 7:
             cmd = dec[:NbCommand.ACK_LEN]
@@ -77,13 +77,13 @@ class NbClient(object):
 
     def receive_handler(self, cmd, payload):
         if self.debug:
-            print("Got cmd:", cmd.hex())
+            print("Got cmd:", cmd.hex(" "))
 
         if cmd == NbCommand.ACK_INIT:
             self.received_key = payload[:16]
             self.received_serial = payload[16:]
             if self.debug:
-                print("> BLE Key:", self.received_key.hex())
+                print("> BLE Key:", self.received_key.hex(" "))
                 print("> Serial:", self.received_serial.decode())
                 print("Setting ble data/key in crypto")
             self.crypto.set_ble_data(self.received_key)
@@ -140,7 +140,7 @@ class NbClient(object):
 
             msg = self.send_buffer.pop()
             if self.debug:
-                print("Sending message:", msg.hex())
+                print("Sending message:", msg.hex(" "))
 
             # frame has 32 - 12 = 20 bytes --> need to chunk!!
             msg_len = len(msg)

--- a/lib/python/test/test_micrypto.py
+++ b/lib/python/test/test_micrypto.py
@@ -38,7 +38,7 @@ class TestMiCrypto(TestCase):
         self.assertEqual(val, priv_val)
         self.assertEqual(bytes.fromhex("b5dca0aec31a8932d0f53cbcbcf0cfdd833c355cada1025cc076e013439ddec2b4017b546a11d79a758db9d015a2ed8926cf82179b593679187d623b5e430fca"),
                          pub,
-                         pub.hex())
+                         pub.hex(" "))
 
     def test_create_e_share_key(self):
         kp1 = MiCrypto.gen_keypair()
@@ -53,19 +53,19 @@ class TestMiCrypto(TestCase):
         derived = MiCrypto.derive_key(secret, bytes([1, 2, 3, 4]))
         self.assertEqual(bytes.fromhex("40ccc0ee058c3a1d37c08e6f72bc2c57c0a406aaa801a0b1b72f22c8c3ec930d3f151e2eb38a2303d8625a18084daa15667496dcfbc53ba3074ce35d6c90d987"),
                          derived,
-                         derived.hex())
+                         derived.hex(" "))
 
         derived = MiCrypto.derive_key(secret)
         self.assertEqual(bytes.fromhex("104ec0eda032b6d213c245359e585d3bfd4b7c5d683c99f49fd86aaf0de0f6b0bfafb897e3b3727aaa8f8ad6b21a737c1d85c3aae340969f268d2d95ca8848c1"),
                          derived,
-                         derived.hex())
+                         derived.hex(" "))
 
     def test_hash(self):
         key = bytes.fromhex("E2B274F08128A62A9575288BED169B3E")
         hash = MiCrypto.hash(key, bytes([1, 2, 3, 4]))
         self.assertEqual(bytes.fromhex("235d7f910974acb594d76a1652a856ce4f269e3060d7c8512e94b2da345d3083"),
                          hash,
-                         hash.hex())
+                         hash.hex(" "))
 
     def test_encrypt_did(self):
         key = bytes.fromhex("4FEB7165982BF1C6183A51B8CADD0EEC")
@@ -86,7 +86,7 @@ class TestMiCrypto(TestCase):
         
     def test_register(self):
         priv_key = MiCrypto.val_to_private_key(48461508383982493215332654270464913273532832436436077476553357014100094140803)
-        #print(MiCrypto.pub_key_to_bytes(priv_key.public_key()).hex())
+        #print(MiCrypto.pub_key_to_bytes(priv_key.public_key()).hex(" "))
         
         remote_info = bytes.fromhex("0100000000626c742e342e31386e35383236366b67673030")
         remote_pub_key = MiCrypto.bytes_to_pub_key(bytes.fromhex("2afe2a8c1c56e5e70721665cd20d017273111ecaeceb1e4d641e7b7a122a9c3041e5cbc962eefbdb155ffd95847a0d8762803291fc2866c5672ceee0e77d77fc"))

--- a/lib/python/test/test_util.py
+++ b/lib/python/test/test_util.py
@@ -23,8 +23,8 @@ from miauth.util import crc16, int_to_bytes
 class Test(TestCase):
     def test_int_to_bytes(self):
         b = int_to_bytes(1337)
-        self.assertEqual(bytes([0x39, 5, 0, 0]), b, b.hex())
+        self.assertEqual(bytes([0x39, 5, 0, 0]), b, b.hex(" "))
 
     def test_crc16(self):
         crc = crc16(bytes([0xa1, 0x21, 0xf3, 4, 5, 6, 7, 8, 9]))
-        self.assertEqual(bytes.fromhex("23fe"), crc, crc.hex())
+        self.assertEqual(bytes.fromhex("23fe"), crc, crc.hex(" "))


### PR DESCRIPTION
e.g.:

```
>>> data = bytes.fromhex("b5dca0aec31a8932d0f53cbcbcf0cfdd833c355cada1025cc076e013439ddec2b4017b546a11d79a758db9d015a2ed8926cf82179b593679187d623b5e430fca")
>>> data.hex()
'b5dca0aec31a8932d0f53cbcbcf0cfdd833c355cada1025cc076e013439ddec2b4017b546a11d79a758db9d015a2ed8926cf82179b593679187d623b5e430fca'
```

vs.

```
>>> data.hex(" ")
'b5 dc a0 ae c3 1a 89 32 d0 f5 3c bc bc f0 cf dd 83 3c 35 5c ad a1 02 5c c0 76 e0 13 43 9d de c2 b4 01 7b 54 6a 11 d7 9a 75 8d b9 d0 15 a2 ed 89 26 cf 82 17 9b 59 36 79 18 7d 62 3b 5e 43 0f ca'
```

I'm currently contemplating whether to port the implementation to my Garmin smartwatch (and their [own programming language...](https://developer.garmin.com/connect-iq/monkey-c/)), and this made it a bit easier to try and understand the whole communication.